### PR TITLE
Add data viz gallery (first chart: Messi penalties)

### DIFF
--- a/public/viz/index.html
+++ b/public/viz/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Data Viz — CMM.dev</title>
+<meta name="description" content="A shelf of one-off data visualizations by Chris McConnell.">
+<style>
+  :root{
+    --ink:#222019; --ink-soft:#6b675c; --ink-faint:#9b968a;
+    --paper:#fbfaf6; --rule:#dcd8cc; --rule-faint:#ece9df;
+    --accent:#9c6b1f; --accent-soft:#c9a35e;
+  }
+  *{box-sizing:border-box;margin:0;padding:0;}
+  html,body{background:var(--paper);color:var(--ink);
+    font-family:Georgia,"Times New Roman",serif;-webkit-font-smoothing:antialiased;line-height:1.45;}
+  body{padding:54px 0 72px;}
+  .wrap{max-width:760px;margin:0 auto;padding:0 28px;}
+  .eyebrow{font-family:"Gill Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-size:11px;letter-spacing:.22em;text-transform:uppercase;color:var(--ink-soft);}
+  h1{font-size:40px;line-height:1.05;letter-spacing:-.01em;margin:12px 0 10px;}
+  .dek{font-size:18px;color:var(--ink-soft);font-style:italic;max-width:54ch;}
+  .rule{height:1px;background:var(--rule);margin:30px 0;}
+  ul{list-style:none;}
+  li{padding:22px 0;border-bottom:1px solid var(--rule-faint);}
+  li:last-child{border-bottom:none;}
+  a.card{text-decoration:none;color:inherit;display:block;}
+  a.card:hover h2{color:var(--accent);}
+  h2{font-size:24px;letter-spacing:-.01em;}
+  .meta{font-family:"Gill Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--ink-faint);margin-top:6px;}
+  .sub{color:var(--ink-soft);margin-top:8px;font-size:16px;max-width:56ch;}
+  .home{font-family:"Gill Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-size:12px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-soft);text-decoration:none;}
+  .home:hover{color:var(--accent);}
+  footer{margin-top:44px;font-family:"Gill Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-size:11px;letter-spacing:.1em;color:var(--ink-faint);}
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <a class="home" href="/">← cmm.dev</a>
+    <div style="height:22px"></div>
+    <div class="eyebrow">CMM.dev</div>
+    <h1>Data Viz</h1>
+    <p class="dek">A shelf for one-off charts — built when a number got stuck in my head and a sketch wouldn't shake it loose.</p>
+    <div class="rule"></div>
+    <ul>
+      <li>
+        <a class="card" href="/viz/messi-from-the-spot/">
+          <h2>Messi From The Spot</h2>
+          <div class="meta">Football · Penalties</div>
+          <p class="sub">Lionel Messi's penalty record, read as an editorial chart.</p>
+        </a>
+      </li>
+    </ul>
+    <footer>More as they get made.</footer>
+  </div>
+</body>
+</html>

--- a/public/viz/messi-from-the-spot/index.html
+++ b/public/viz/messi-from-the-spot/index.html
@@ -1,0 +1,448 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Messi From The Spot</title>
+<style>
+  :root{
+    --ink:#222019;
+    --ink-soft:#6b675c;
+    --ink-faint:#9b968a;
+    --paper:#fbfaf6;
+    --rule:#dcd8cc;
+    --rule-faint:#ece9df;
+    --accent:#9c6b1f;      /* muted ochre, the one accent */
+    --accent-soft:#c9a35e;
+    --good:#3f6e4b;
+    --bad:#a8503f;
+  }
+  *{box-sizing:border-box;margin:0;padding:0;}
+  html,body{background:var(--paper);color:var(--ink);
+    font-family:Georgia,"Times New Roman",serif;-webkit-font-smoothing:antialiased;
+    line-height:1.45;}
+  body{padding:54px 0 72px;}
+  .wrap{max-width:760px;margin:0 auto;padding:0 28px;}
+  .sans{font-family:"Gill Sans","Helvetica Neue",Helvetica,Arial,sans-serif;}
+
+  /* MASTHEAD */
+  .eyebrow{font-family:"Gill Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-size:11px;letter-spacing:.22em;text-transform:uppercase;color:var(--ink-soft);
+    font-weight:600;}
+  h1{font-size:clamp(30px,5.5vw,46px);line-height:1.04;font-weight:400;
+    letter-spacing:-.01em;margin:8px 0 10px;}
+  h1 em{font-style:italic;}
+  .standfirst{font-size:16px;color:var(--ink-soft);max-width:60ch;line-height:1.5;}
+  .rule{border:0;border-top:1px solid var(--ink);margin:26px 0 0;}
+  .rule.thin{border-top:1px solid var(--rule);}
+
+  /* SENTENCE STATS (data in the flow of text, Tufte-style) */
+  .lead-stats{margin:30px 0 6px;font-size:19px;line-height:1.65;}
+  .lead-stats b{font-weight:400;font-size:25px;font-variant-numeric:tabular-nums;
+    border-bottom:2px solid var(--accent-soft);padding-bottom:1px;}
+
+  /* SECTION */
+  section{margin-top:46px;}
+  .sec-label{font-family:"Gill Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-size:12px;letter-spacing:.16em;text-transform:uppercase;color:var(--ink-soft);
+    font-weight:600;margin-bottom:4px;}
+  h2{font-size:23px;font-weight:400;letter-spacing:-.01em;margin-bottom:6px;}
+  .note{font-size:14px;color:var(--ink-soft);max-width:62ch;line-height:1.5;}
+
+  /* GOAL GRID — Tufte: thin frame, no fill chrome, value printed in cell */
+  .goalfig{margin:24px 0 4px;}
+  .goalwrap{position:relative;width:100%;max-width:520px;}
+  svg{width:100%;height:auto;display:block;}
+  .axis-x{font-family:"Gill Sans",Helvetica,Arial,sans-serif;font-size:10.5px;
+    letter-spacing:.04em;fill:var(--ink-soft);}
+  .axis-y{font-family:"Gill Sans",Helvetica,Arial,sans-serif;font-size:10px;
+    letter-spacing:.06em;fill:var(--ink-faint);text-transform:uppercase;}
+  .cellval{font-family:"Gill Sans",Helvetica,Arial,sans-serif;font-weight:600;
+    font-variant-numeric:tabular-nums;}
+  .figcap{font-size:13px;color:var(--ink-soft);margin-top:14px;line-height:1.5;
+    max-width:58ch;}
+  .figcap b{color:var(--ink);font-weight:400;border-bottom:1.5px solid var(--accent-soft);}
+
+  /* SIDE COMPARISON — slope / dot style, minimal */
+  .sides{margin-top:26px;display:grid;grid-template-columns:1fr;gap:0;}
+  .siderow{display:grid;grid-template-columns:120px 1fr 78px;align-items:center;
+    gap:14px;padding:11px 0;border-top:1px solid var(--rule-faint);}
+  .siderow:first-child{border-top:1px solid var(--rule);}
+  .sidename{font-size:15px;}
+  .sidename .small{display:block;font-size:11.5px;color:var(--ink-soft);
+    font-family:"Gill Sans",Helvetica,Arial,sans-serif;}
+  .track{position:relative;height:9px;}
+  .track .base{position:absolute;top:50%;left:0;right:0;height:1px;background:var(--rule);}
+  .track .freq{position:absolute;top:50%;transform:translateY(-50%);height:9px;
+    background:var(--accent);opacity:.85;}
+  .sideval{text-align:right;font-family:"Gill Sans",Helvetica,Arial,sans-serif;
+    font-size:13px;font-variant-numeric:tabular-nums;color:var(--ink-soft);}
+  .sideval b{color:var(--ink);font-weight:600;}
+  .insight{margin-top:18px;font-size:15px;line-height:1.6;border-left:2px solid var(--accent-soft);
+    padding-left:16px;color:var(--ink);max-width:60ch;}
+
+  /* SPARK / CAREER ROW (small multiples vibe, minimal) */
+  .tablewrap{margin-top:20px;}
+  .filters{display:flex;flex-wrap:wrap;gap:6px;align-items:center;margin-bottom:14px;}
+  .chip{font-family:"Gill Sans",Helvetica,Arial,sans-serif;font-size:12px;
+    padding:5px 11px;border:1px solid var(--rule);background:transparent;cursor:pointer;
+    color:var(--ink-soft);border-radius:2px;transition:.12s;}
+  .chip:hover{border-color:var(--ink-faint);color:var(--ink);}
+  .chip.on{background:var(--ink);color:var(--paper);border-color:var(--ink);}
+  .fsep{width:1px;height:18px;background:var(--rule);margin:0 4px;}
+  .fcount{margin-left:auto;font-family:"Gill Sans",Helvetica,Arial,sans-serif;
+    font-size:12px;color:var(--ink-faint);}
+  .tbl-scroll{max-height:430px;overflow:auto;border-top:1.5px solid var(--ink);
+    border-bottom:1.5px solid var(--ink);}
+  table{width:100%;border-collapse:collapse;font-size:13.5px;}
+  thead th{position:sticky;top:0;background:var(--paper);text-align:left;
+    font-family:"Gill Sans",Helvetica,Arial,sans-serif;font-size:11px;font-weight:600;
+    letter-spacing:.08em;text-transform:uppercase;color:var(--ink-soft);
+    padding:9px 10px 7px;cursor:pointer;border-bottom:1px solid var(--ink);white-space:nowrap;}
+  thead th:hover{color:var(--ink);}
+  tbody td{padding:7px 10px;border-bottom:1px solid var(--rule-faint);
+    font-variant-numeric:tabular-nums;}
+  tbody tr:hover{background:#f3f0e7;}
+  .out-s{color:var(--good);}
+  .out-m{color:var(--bad);}
+  .marker{font-family:"Gill Sans",Helvetica,Arial,sans-serif;font-size:11px;}
+  .comp{font-family:"Gill Sans",Helvetica,Arial,sans-serif;font-size:11px;
+    color:var(--ink-soft);}
+  td.opp{font-style:italic;}
+  .src{font-size:12px;color:var(--ink-faint);margin-top:18px;line-height:1.55;}
+  .src a{color:var(--accent);}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="eyebrow">Lionel Messi &middot; 147 career penalties</div>
+  <h1>From the <em>spot</em></h1>
+  <p class="standfirst">Where the most analyzed left foot in football sends the ball &mdash; and the quiet paradox in the numbers.</p>
+  <hr class="rule">
+
+  <p class="lead-stats">
+    Across nineteen years Messi has stepped up <b>147</b> times, scored <b>114</b>,
+    and been denied <b>33</b> &mdash; a conversion rate of <b>78%</b>, almost exactly the
+    elite-league average for a high-volume taker.
+  </p>
+
+  <!-- PLACEMENT GRID -->
+  <section>
+    <div class="sec-label">Placement &middot; shooter's view</div>
+    <h2>His right, kept low</h2>
+    <p class="note">Each cell shows the share of penalties sent there. Read it as the shooter sees the goal: his left hand side on the left, his right on the right.</p>
+
+    <div class="goalfig">
+      <div class="goalwrap">
+        <svg viewBox="0 0 520 330" preserveAspectRatio="xMidYMid meet" aria-label="Nine-zone goal grid, Messi penalty placement, shooter's view">
+          <!-- y labels -->
+          <text class="axis-y" x="6" y="78"  >High</text>
+          <text class="axis-y" x="6" y="170" >Mid</text>
+          <text class="axis-y" x="6" y="262" >Low</text>
+
+          <!-- goal frame: thin, only the posts+bar, no fill -->
+          <line x1="70" y1="36" x2="70"  y2="300" stroke="#222019" stroke-width="2"/>
+          <line x1="470" y1="36" x2="470" y2="300" stroke="#222019" stroke-width="2"/>
+          <line x1="70" y1="36" x2="470" y2="36" stroke="#222019" stroke-width="2"/>
+          <line x1="60" y1="300" x2="480" y2="300" stroke="#dcd8cc" stroke-width="1"/>
+
+          <!-- faint interior dividers (data-ink minimal) -->
+          <line x1="203" y1="36" x2="203" y2="300" stroke="#ece9df" stroke-width="1"/>
+          <line x1="337" y1="36" x2="337" y2="300" stroke="#ece9df" stroke-width="1"/>
+          <line x1="70" y1="124" x2="470" y2="124" stroke="#ece9df" stroke-width="1"/>
+          <line x1="70" y1="212" x2="470" y2="212" stroke="#ece9df" stroke-width="1"/>
+
+          <!-- value dots: radius encodes share, single accent color.
+               columns center x: left 136, centre 270, right 404
+               rows center y: high 80, mid 168, low 256
+               Shares (estimated from side split + low/mid lean; rounded, must total ~100):
+               left  : high 4, mid 12, low 17   (=33)
+               centre: high 1, mid 3,  low 4    (=8)
+               right : high 9, mid 21, low 30   (=60)  -> bottom-right dominant -->
+          <!-- left col -->
+          <circle cx="136" cy="80"  r="7"  fill="#9c6b1f" opacity="0.78"/>
+          <text class="cellval" x="136" y="103" text-anchor="middle" font-size="11" fill="#6b675c">4%</text>
+          <circle cx="136" cy="168" r="13" fill="#9c6b1f" opacity="0.82"/>
+          <text class="cellval" x="136" y="196" text-anchor="middle" font-size="12" fill="#6b675c">12%</text>
+          <circle cx="136" cy="256" r="16" fill="#9c6b1f" opacity="0.85"/>
+          <text class="cellval" x="136" y="287" text-anchor="middle" font-size="12" fill="#6b675c">17%</text>
+          <!-- centre col -->
+          <circle cx="270" cy="80"  r="3.5" fill="#c9a35e" opacity="0.8"/>
+          <text class="cellval" x="270" y="100" text-anchor="middle" font-size="10.5" fill="#9b968a">1%</text>
+          <circle cx="270" cy="168" r="6"  fill="#c9a35e" opacity="0.8"/>
+          <text class="cellval" x="270" y="190" text-anchor="middle" font-size="10.5" fill="#9b968a">3%</text>
+          <circle cx="270" cy="256" r="7"  fill="#c9a35e" opacity="0.8"/>
+          <text class="cellval" x="270" y="280" text-anchor="middle" font-size="10.5" fill="#9b968a">4%</text>
+          <!-- right col -->
+          <circle cx="404" cy="80"  r="11" fill="#9c6b1f" opacity="0.85"/>
+          <text class="cellval" x="404" y="105" text-anchor="middle" font-size="12" fill="#6b675c">9%</text>
+          <circle cx="404" cy="168" r="18" fill="#9c6b1f" opacity="0.9"/>
+          <text class="cellval" x="404" y="200" text-anchor="middle" font-size="12.5" fill="#4a463c">21%</text>
+          <circle cx="404" cy="256" r="22" fill="#9c6b1f" opacity="0.96"/>
+          <text class="cellval" x="404" y="291" text-anchor="middle" font-size="13.5" font-weight="700" fill="#222019">30%</text>
+
+          <!-- x labels -->
+          <text class="axis-x" x="136" y="320" text-anchor="middle">His left</text>
+          <text class="axis-x" x="270" y="320" text-anchor="middle">Centre</text>
+          <text class="axis-x" x="404" y="320" text-anchor="middle">His right</text>
+        </svg>
+      </div>
+      <p class="figcap">Dot size is the share of penalties to each zone. The heaviest dot sits <b>bottom-right &mdash; his right, low</b>: the intersection of his preferred side and his low-to-mid habit. Centre is nearly empty.</p>
+    </div>
+  </section>
+
+  <!-- THE PARADOX -->
+  <section>
+    <div class="sec-label">The paradox</div>
+    <h2>He shoots right, but scores left</h2>
+    <p class="note">Side split and conversion from a 95-penalty Barcelona sample &mdash; the most granular public placement data that exists.</p>
+
+    <div class="sides">
+      <div class="siderow">
+        <div class="sidename">His right<span class="small">the &ldquo;safety side&rdquo;</span></div>
+        <div class="track"><div class="base"></div><div class="freq" style="width:60%"></div></div>
+        <div class="sideval"><b>60%</b> of kicks</div>
+      </div>
+      <div class="siderow">
+        <div class="sidename">His left<span class="small">used less, missed less</span></div>
+        <div class="track"><div class="base"></div><div class="freq" style="width:33%"></div></div>
+        <div class="sideval"><b>33%</b> of kicks</div>
+      </div>
+      <div class="siderow">
+        <div class="sidename">Centre<span class="small">the rarity</span></div>
+        <div class="track"><div class="base"></div><div class="freq" style="width:8%"></div></div>
+        <div class="sideval"><b>8%</b> of kicks</div>
+      </div>
+    </div>
+
+    <p class="insight">
+      He goes right almost twice as often, yet converts <b>86.7%</b> to his left versus
+      <b>77.2%</b> to his right. The favorite side is the <em>less</em> efficient one &mdash;
+      keepers anticipate it and still mostly fail, but the under-used left is where he's
+      deadliest.
+    </p>
+  </section>
+
+  <!-- FULL LOG -->
+  <section>
+    <div class="sec-label">The record</div>
+    <h2>Every penalty, 2007&ndash;2026</h2>
+    <p class="note">Outcome and goalkeeper are logged; in-goal coordinates are not published for the full career. Filter and sort below.</p>
+
+    <div class="tablewrap">
+      <div class="filters">
+        <div id="f-outcome" style="display:flex;gap:6px;">
+          <button class="chip on" data-f="all">All</button>
+          <button class="chip" data-f="scored">Scored</button>
+          <button class="chip" data-f="missed">Missed</button>
+        </div>
+        <span class="fsep"></span>
+        <div id="f-team" style="display:flex;gap:6px;flex-wrap:wrap;">
+          <button class="chip on" data-t="all">All teams</button>
+          <button class="chip" data-t="Barcelona">Barcelona</button>
+          <button class="chip" data-t="PSG">PSG</button>
+          <button class="chip" data-t="Miami">Miami</button>
+          <button class="chip" data-t="Argentina">Argentina</button>
+        </div>
+        <span class="fcount" id="fcount"></span>
+      </div>
+      <div class="tbl-scroll">
+        <table>
+          <thead>
+            <tr>
+              <th data-sort="date">Date</th>
+              <th data-sort="comp">Comp</th>
+              <th data-sort="team">Team</th>
+              <th data-sort="opp">Opponent</th>
+              <th data-sort="min">Min</th>
+              <th data-sort="out">Result</th>
+            </tr>
+          </thead>
+          <tbody id="tbody"></tbody>
+        </table>
+      </div>
+      <p class="src">
+        Penalty log: <a href="https://www.messistats.com/en/penalty" target="_blank">MessiStats</a>.
+        Conversion cross-checked with <a href="https://www.messivsronaldo.app/detailed-stats/penalties/" target="_blank">messivsronaldo.app</a>
+        and <a href="https://www.transfermarkt.us/lionel-messi/elfmetertore/spieler/28003" target="_blank">Transfermarkt</a>.
+        Side split &amp; conversion: <a href="https://m.allfootballapp.com/news/EPL/Analyzing-Messis-penalties-where-he-shoots-reliability--safety-side/2269484" target="_blank">All Football</a> (95-penalty Barcelona sample).
+        Vertical (high/mid/low) shares are estimated from the documented side split plus his low-to-mid lean &mdash; no public source plots exact placement for all kicks.
+      </p>
+    </div>
+  </section>
+
+</div>
+
+<script>
+const D = [
+  ["2026-06-22","WCP","Argentina","Austria",9,"missed"],
+  ["2026-06-09","FRN","Argentina","Iceland",72,"scored"],
+  ["2026-04-18","MLS","Miami","Colorado Rapids",18,"scored"],
+  ["2025-10-19","MLS","Miami","Nashville SC",63,"scored"],
+  ["2025-09-13","MLS","Miami","Charlotte FC",32,"missed"],
+  ["2025-08-27","NAM","Miami","Orlando City",77,"scored"],
+  ["2025-04-09","NAM","Miami","Los Angeles FC",84,"scored"],
+  ["2024-04-20","MLS","Miami","Nashville SC",81,"scored"],
+  ["2022-12-18","WCP","Argentina","France",23,"scored"],
+  ["2022-12-13","WCP","Argentina","Croatia",34,"scored"],
+  ["2022-12-09","WCP","Argentina","Netherlands",73,"scored"],
+  ["2022-11-30","WCP","Argentina","Poland",38,"missed"],
+  ["2022-11-22","WCP","Argentina","Saudi Arabia",10,"scored"],
+  ["2022-09-23","FRN","Argentina","Honduras",45,"scored"],
+  ["2022-06-05","FRN","Argentina","Estonia",8,"scored"],
+  ["2022-02-15","EUR","PSG","Real Madrid",61,"missed"],
+  ["2021-12-07","EUR","PSG","Club Brugge",76,"scored"],
+  ["2021-10-19","EUR","PSG","RB Leipzig",74,"scored"],
+  ["2021-06-28","CPA","Argentina","Bolivia",33,"scored"],
+  ["2021-06-04","WCQ","Argentina","Chile",23,"scored"],
+  ["2021-05-02","PRM","Barcelona","Valencia",57,"missed"],
+  ["2021-03-10","EUR","Barcelona","PSG",45,"missed"],
+  ["2021-02-21","PRM","Barcelona","Cadiz",32,"scored"],
+  ["2021-02-16","EUR","Barcelona","PSG",28,"scored"],
+  ["2020-12-19","PRM","Barcelona","Valencia",45,"missed"],
+  ["2020-11-07","PRM","Barcelona","Real Betis",61,"scored"],
+  ["2020-11-04","EUR","Barcelona","Dynamo Kyiv",5,"scored"],
+  ["2020-10-28","EUR","Barcelona","Juventus",90,"scored"],
+  ["2020-10-20","EUR","Barcelona","Ferencvaros",27,"scored"],
+  ["2020-10-09","WCQ","Argentina","Ecuador",13,"scored"],
+  ["2020-09-27","PRM","Barcelona","Villarreal",35,"scored"],
+  ["2020-06-30","PRM","Barcelona","Atletico Madrid",50,"scored"],
+  ["2020-06-16","PRM","Barcelona","Leganes",69,"scored"],
+  ["2020-03-07","PRM","Barcelona","Real Sociedad",81,"scored"],
+  ["2019-11-18","FRN","Argentina","Uruguay",90,"scored"],
+  ["2019-11-15","FRN","Argentina","Brazil",13,"missed"],
+  ["2019-11-09","PRM","Barcelona","Celta de Vigo",23,"scored"],
+  ["2019-11-02","PRM","Barcelona","Levante",38,"scored"],
+  ["2019-06-19","CPA","Argentina","Paraguay",57,"scored"],
+  ["2019-03-13","EUR","Barcelona","Olympique Lyonnais",18,"scored"],
+  ["2019-03-09","PRM","Barcelona","Rayo Vallecano",51,"scored"],
+  ["2019-02-16","PRM","Barcelona","Real Valladolid",85,"missed"],
+  ["2019-02-16","PRM","Barcelona","Real Valladolid",43,"scored"],
+  ["2019-02-02","PRM","Barcelona","Valencia",39,"scored"],
+  ["2018-11-11","PRM","Barcelona","Real Betis",68,"scored"],
+  ["2018-06-16","WCP","Argentina","Iceland",64,"missed"],
+  ["2018-05-29","FRN","Argentina","Haiti",17,"scored"],
+  ["2018-01-17","CUP","Barcelona","Espanyol",62,"missed"],
+  ["2017-12-23","PRM","Barcelona","Real Madrid",64,"scored"],
+  ["2017-12-17","PRM","Barcelona","Deportivo La Coruna",70,"missed"],
+  ["2017-09-19","PRM","Barcelona","Eibar",20,"scored"],
+  ["2017-08-26","PRM","Barcelona","Alaves",39,"missed"],
+  ["2017-08-13","SUP","Barcelona","Real Madrid",76,"scored"],
+  ["2017-05-21","PRM","Barcelona","Eibar",76,"scored"],
+  ["2017-05-21","PRM","Barcelona","Eibar",69,"missed"],
+  ["2017-05-06","PRM","Barcelona","Villarreal",82,"scored"],
+  ["2017-03-23","WCQ","Argentina","Chile",16,"scored"],
+  ["2017-03-19","PRM","Barcelona","Valencia",45,"scored"],
+  ["2017-03-08","EUR","Barcelona","PSG",50,"scored"],
+  ["2017-02-19","PRM","Barcelona","Leganes",89,"scored"],
+  ["2017-01-26","CUP","Barcelona","Real Sociedad",55,"scored"],
+  ["2016-11-23","EUR","Barcelona","Celtic",55,"scored"],
+  ["2016-10-22","PRM","Barcelona","Valencia",90,"scored"],
+  ["2016-09-17","PRM","Barcelona","Leganes",55,"scored"],
+  ["2016-03-29","WCQ","Argentina","Bolivia",30,"scored"],
+  ["2016-03-12","PRM","Barcelona","Getafe",11,"missed"],
+  ["2016-03-06","PRM","Barcelona","Eibar",76,"scored"],
+  ["2016-02-23","EUR","Barcelona","Arsenal",83,"scored"],
+  ["2016-02-14","PRM","Barcelona","Celta de Vigo",81,"scored"],
+  ["2016-01-17","PRM","Barcelona","Athletic Bilbao",7,"scored"],
+  ["2015-09-20","PRM","Barcelona","Levante",75,"missed"],
+  ["2015-09-20","PRM","Barcelona","Levante",61,"scored"],
+  ["2015-08-23","PRM","Barcelona","Athletic Bilbao",31,"missed"],
+  ["2015-06-13","CPA","Argentina","Paraguay",35,"scored"],
+  ["2015-04-28","PRM","Barcelona","Getafe",9,"scored"],
+  ["2015-03-14","PRM","Barcelona","Eibar",31,"scored"],
+  ["2015-03-08","PRM","Barcelona","Rayo Vallecano",56,"scored"],
+  ["2015-02-24","EUR","Barcelona","Manchester City",90,"missed"],
+  ["2015-02-15","PRM","Barcelona","Levante",65,"scored"],
+  ["2015-01-24","PRM","Barcelona","Elche",55,"scored"],
+  ["2015-01-21","CUP","Barcelona","Atletico Madrid",85,"missed"],
+  ["2015-01-08","CUP","Barcelona","Elche",45,"scored"],
+  ["2014-11-12","FRN","Argentina","Croatia",57,"scored"],
+  ["2014-10-11","FRN","Argentina","Brazil",41,"missed"],
+  ["2014-09-21","PRM","Barcelona","Levante",42,"missed"],
+  ["2014-04-05","PRM","Barcelona","Real Betis",86,"missed"],
+  ["2014-04-05","PRM","Barcelona","Real Betis",15,"scored"],
+  ["2014-03-29","PRM","Barcelona","Espanyol",77,"scored"],
+  ["2014-03-23","PRM","Barcelona","Real Madrid",84,"scored"],
+  ["2014-03-23","PRM","Barcelona","Real Madrid",65,"scored"],
+  ["2014-02-18","EUR","Barcelona","Manchester City",54,"scored"],
+  ["2014-02-01","PRM","Barcelona","Valencia",54,"scored"],
+  ["2013-11-06","EUR","Barcelona","AC Milan",30,"scored"],
+  ["2013-09-11","WCQ","Argentina","Paraguay",52,"scored"],
+  ["2013-09-11","WCQ","Argentina","Paraguay",12,"scored"],
+  ["2013-08-28","SUP","Barcelona","Atletico Madrid",89,"missed"],
+  ["2013-08-18","PRM","Barcelona","Levante",42,"scored"],
+  ["2013-06-15","FRN","Argentina","Guatemala",40,"scored"],
+  ["2013-03-23","WCQ","Argentina","Venezuela",44,"scored"],
+  ["2013-02-03","PRM","Barcelona","Valencia",39,"scored"],
+  ["2013-01-27","PRM","Barcelona","Osasuna",28,"scored"],
+  ["2013-01-06","PRM","Barcelona","Espanyol",29,"scored"],
+  ["2012-09-15","PRM","Barcelona","Getafe",74,"scored"],
+  ["2012-08-23","SUP","Barcelona","Real Madrid",70,"scored"],
+  ["2012-08-15","FRN","Argentina","Germany",32,"missed"],
+  ["2012-05-05","PRM","Barcelona","Espanyol",79,"scored"],
+  ["2012-05-05","PRM","Barcelona","Espanyol",64,"scored"],
+  ["2012-05-02","PRM","Barcelona","Malaga",59,"scored"],
+  ["2012-05-02","PRM","Barcelona","Malaga",35,"scored"],
+  ["2012-04-24","EUR","Barcelona","Chelsea",49,"missed"],
+  ["2012-04-14","PRM","Barcelona","Levante",72,"scored"],
+  ["2012-04-07","PRM","Barcelona","Real Zaragoza",86,"scored"],
+  ["2012-04-03","EUR","Barcelona","AC Milan",41,"scored"],
+  ["2012-04-03","EUR","Barcelona","AC Milan",11,"scored"],
+  ["2012-03-31","PRM","Barcelona","Athletic Bilbao",58,"scored"],
+  ["2012-03-11","PRM","Barcelona","Racing Santander",56,"scored"],
+  ["2012-02-29","FRN","Argentina","Switzerland",90,"scored"],
+  ["2012-02-01","CUP","Barcelona","Valencia",56,"missed"],
+  ["2012-01-15","PRM","Barcelona","Real Betis",86,"scored"],
+  ["2011-11-23","EUR","Barcelona","AC Milan",31,"scored"],
+  ["2011-11-01","EUR","Barcelona","Viktoria Plzen",24,"scored"],
+  ["2011-10-29","PRM","Barcelona","Real Mallorca",13,"scored"],
+  ["2011-10-22","PRM","Barcelona","Sevilla",90,"missed"],
+  ["2011-04-16","PRM","Barcelona","Real Madrid",53,"scored"],
+  ["2011-04-09","PRM","Barcelona","UD Almeria",53,"scored"],
+  ["2011-03-08","EUR","Barcelona","Arsenal",71,"scored"],
+  ["2011-02-09","FRN","Argentina","Portugal",90,"scored"],
+  ["2011-01-22","PRM","Barcelona","Racing Santander",33,"scored"],
+  ["2011-01-19","CUP","Barcelona","Real Betis",54,"missed"],
+  ["2010-12-04","PRM","Barcelona","Osasuna",83,"scored"],
+  ["2010-09-14","EUR","Barcelona","Panathinaikos",55,"missed"],
+  ["2009-11-14","FRN","Argentina","Spain",61,"scored"],
+  ["2009-11-07","PRM","Barcelona","Real Mallorca",87,"scored"],
+  ["2009-08-23","SUP","Barcelona","Athletic Bilbao",68,"scored"],
+  ["2009-04-11","PRM","Barcelona","Recreativo Huelva",81,"missed"],
+  ["2009-03-07","PRM","Barcelona","Athletic Bilbao",32,"scored"],
+  ["2009-01-06","CUP","Barcelona","Atletico Madrid",57,"scored"],
+  ["2008-11-12","CUP","Barcelona","Benidorm",87,"missed"],
+  ["2008-09-27","PRM","Barcelona","Espanyol",90,"scored"],
+  ["2008-09-13","PRM","Barcelona","Racing Santander",71,"scored"],
+  ["2008-05-04","PRM","Barcelona","Valencia",6,"scored"],
+  ["2008-01-31","CUP","Barcelona","Villarreal",76,"missed"],
+  ["2007-11-27","EUR","Barcelona","Olympique Lyonnais",58,"scored"],
+  ["2007-11-24","PRM","Barcelona","Recreativo Huelva",82,"scored"],
+  ["2007-10-28","PRM","Barcelona","UD Almeria",81,"scored"],
+  ["2007-09-22","PRM","Barcelona","Sevilla",80,"scored"]
+];
+const COMP_LABEL={WCP:"World Cup",FRN:"Friendly",MLS:"MLS",NAM:"Leagues Cup",EUR:"UCL",CPA:"Copa Am.",WCQ:"WC Qual.",PRM:"League",CUP:"Copa del Rey",SUP:"Super Cup"};
+const TEAM_LABEL={Barcelona:"Barcelona",PSG:"PSG",Miami:"Inter Miami",Argentina:"Argentina"};
+let state={outcome:"all",team:"all",sortKey:"date",sortDir:-1};
+const tbody=document.getElementById('tbody'),fcount=document.getElementById('fcount');
+function fmtDate(d){const[y,m,day]=d.split('-');const mo=["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"][+m-1];return `${mo} ${+day}, ’${y.slice(2)}`;}
+function render(){
+  let rows=D.filter(r=>(state.outcome==="all"||r[5]===state.outcome)&&(state.team==="all"||r[2]===state.team));
+  const idx={date:0,comp:1,team:2,opp:3,min:4,out:5}[state.sortKey];
+  rows.sort((a,b)=>{let av=a[idx],bv=b[idx];if(state.sortKey==="min"){av=+av;bv=+bv;}return av<bv?-1*state.sortDir:av>bv?state.sortDir:0;});
+  tbody.innerHTML=rows.map(r=>{
+    const out=r[5]==="scored"?'<span class="out-s marker">&#9679; Scored</span>':'<span class="out-m marker">&#9675; Missed</span>';
+    return `<tr><td>${fmtDate(r[0])}</td><td class="comp">${COMP_LABEL[r[1]]||r[1]}</td><td>${TEAM_LABEL[r[2]]}</td><td class="opp">${r[3]}</td><td>${r[4]}'</td><td>${out}</td></tr>`;
+  }).join('');
+  const sc=rows.filter(r=>r[5]==="scored").length;
+  fcount.textContent=`${rows.length} shown · ${sc} scored · ${rows.length-sc} missed`;
+}
+document.querySelectorAll('#f-outcome .chip').forEach(b=>b.onclick=()=>{document.querySelectorAll('#f-outcome .chip').forEach(x=>x.classList.remove('on'));b.classList.add('on');state.outcome=b.dataset.f;render();});
+document.querySelectorAll('#f-team .chip').forEach(b=>b.onclick=()=>{document.querySelectorAll('#f-team .chip').forEach(x=>x.classList.remove('on'));b.classList.add('on');state.team=b.dataset.t;render();});
+document.querySelectorAll('thead th').forEach(th=>th.onclick=()=>{const k=th.dataset.sort;if(state.sortKey===k)state.sortDir*=-1;else{state.sortKey=k;state.sortDir=(k==="date")?-1:1;}render();});
+render();
+</script>
+</body>
+</html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -416,7 +416,7 @@ function layoutAbout(w: number, _h: number): Line[] {
     ["humaine.studio", "https://humaine.studio"],
     ["eagleridge.io", "https://eagleridge.io"],
     ["linkedin.com/in/c-mcconnell", "https://www.linkedin.com/in/c-mcconnell/"],
-    ["data viz", "/viz"],
+    ["data viz", "/viz/"],
   ]
   for (const [label, href] of links) {
     out.push({ x: gutter + 16, y, text: label, color: C.border, font, lineHeight: lh, href })
@@ -452,8 +452,11 @@ function renderLines(lines: Line[]): void {
     if (line.href) {
       const a = document.createElement("a")
       a.href = line.href
-      a.target = "_blank"
-      a.rel = "noreferrer"
+      // Internal links (root-relative) navigate in place; external links open a new tab.
+      if (/^https?:/.test(line.href)) {
+        a.target = "_blank"
+        a.rel = "noreferrer"
+      }
       a.className = "ln"
       el = a
     } else if (line.navTarget) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -416,6 +416,7 @@ function layoutAbout(w: number, _h: number): Line[] {
     ["humaine.studio", "https://humaine.studio"],
     ["eagleridge.io", "https://eagleridge.io"],
     ["linkedin.com/in/c-mcconnell", "https://www.linkedin.com/in/c-mcconnell/"],
+    ["data viz", "/viz"],
   ]
   for (const [label, href] of links) {
     out.push({ x: gutter + 16, y, text: label, color: C.border, font, lineHeight: lh, href })


### PR DESCRIPTION
## What

A `/viz` page on cmm.dev to collect one-off data visualizations, plus the first entry.

- **`public/viz/index.html`** — editorial gallery index, served at `/viz`. Matches the chart's serif/paper/ochre aesthetic.
- **`public/viz/messi-from-the-spot/index.html`** — first chart (self-contained, Messi penalty record).
- **`src/main.ts`** — adds a `data viz → /viz` entry to the TUI home links list for discoverability.

## How it ships

Vite copies `public/` into `dist/` at build time, so the existing CF Pages deploy (`pages deploy dist`) serves `/viz` and `/viz/messi-from-the-spot/` with no config change. Adding future charts = drop a folder under `public/viz/` + one `<li>` in the gallery.

## Verified

- `bun install --frozen-lockfile && bun run build` green; `dist/viz/` populated as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)